### PR TITLE
Add responsive navigation collapse

### DIFF
--- a/app/Views/layout.php
+++ b/app/Views/layout.php
@@ -18,6 +18,13 @@ $robots = $robots ?? 'index,follow';
 // AMP veya mobil alternatif (opsiyonel; post view set edebilir)
 $ampUrl    = $ampUrl    ?? null;
 $mobileUrl = $mobileUrl ?? null;
+
+$navLinks = [
+  ['label' => 'Home',   'href' => '/' . $lang . '/'],
+  ['label' => 'Trends', 'href' => '/' . $lang . '/section/trends'],
+  ['label' => 'Tech',   'href' => '/' . $lang . '/section/tech'],
+  ['label' => 'World',  'href' => '/' . $lang . '/section/world'],
+];
 ?>
 <!doctype html>
 <html lang="<?= htmlspecialchars($lang) ?>" dir="<?= htmlspecialchars($dir) ?>">
@@ -52,33 +59,46 @@ $mobileUrl = $mobileUrl ?? null;
       <a class="e2-brand" href="/<?= htmlspecialchars($lang) ?>/">
         <img src="/assets/logo.png" alt="<?= htmlspecialchars($siteName) ?>" width="96">
       </a>
+      <button class="btn e2-nav-toggle d-md-none" type="button" data-bs-toggle="collapse" data-bs-target="#primaryNav" aria-controls="primaryNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="e2-nav-toggle-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Menu</span>
+      </button>
 
-      <nav class="d-none d-md-flex align-items-center gap-3">
-        <a href="/<?= htmlspecialchars($lang) ?>/" class="muted">Home</a>
-        <a href="/<?= htmlspecialchars($lang) ?>/section/trends" class="muted">Trends</a>
-        <a href="/<?= htmlspecialchars($lang) ?>/section/tech" class="muted">Tech</a>
-        <a href="/<?= htmlspecialchars($lang) ?>/section/world" class="muted">World</a>
+      <nav class="flex-grow-1" aria-label="Primary navigation">
+        <div class="collapse d-md-flex" id="primaryNav">
+          <div class="e2-nav-menu">
+            <ul class="e2-nav-links list-unstyled mb-0">
+              <?php foreach ($navLinks as $link): ?>
+                <li>
+                  <a href="<?= htmlspecialchars($link['href']) ?>" class="muted"><?= htmlspecialchars($link['label']) ?></a>
+                </li>
+              <?php endforeach; ?>
+            </ul>
 
-        <!-- Dil menüsü -->
-        <div class="dropdown">
-          <a class="e2-btn ghost dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            <?= strtoupper(htmlspecialchars($lang)) ?>
-          </a>
-          <ul class="dropdown-menu dropdown-menu-end">
-            <?php
-            $supported = array_keys(I18n::supported());
-            $current = $_SERVER['REQUEST_URI'] ?? '/';
-            foreach ($supported as $code):
-              $next = preg_replace('~^/[a-z-]+/~', '/' . $code . '/', $current);
-              if ($next === null) $next = '/' . $code . '/';
-              $langUrl = '/lang/' . $code . '?next=' . rawurlencode($next);
-            ?>
-              <li><a class="dropdown-item" href="<?= htmlspecialchars($langUrl) ?>"><?= strtoupper(htmlspecialchars($code)) ?></a></li>
-            <?php endforeach; ?>
-          </ul>
+            <div class="e2-nav-controls">
+              <!-- Dil menüsü -->
+              <div class="dropdown">
+                <a class="e2-btn ghost dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                  <?= strtoupper(htmlspecialchars($lang)) ?>
+                </a>
+                <ul class="dropdown-menu dropdown-menu-end">
+                  <?php
+                  $supported = array_keys(I18n::supported());
+                  $current = $_SERVER['REQUEST_URI'] ?? '/';
+                  foreach ($supported as $code):
+                    $next = preg_replace('~^/[a-z-]+/~', '/' . $code . '/', $current);
+                    if ($next === null) $next = '/' . $code . '/';
+                    $langUrl = '/lang/' . $code . '?next=' . rawurlencode($next);
+                  ?>
+                    <li><a class="dropdown-item" href="<?= htmlspecialchars($langUrl) ?>"><?= strtoupper(htmlspecialchars($code)) ?></a></li>
+                  <?php endforeach; ?>
+                </ul>
+              </div>
+
+              <button id="theme-toggle" class="e2-btn ghost" type="button" aria-label="Toggle theme">Theme</button>
+            </div>
+          </div>
         </div>
-
-        <button id="theme-toggle" class="e2-btn ghost" type="button" aria-label="Toggle theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -124,7 +124,59 @@
     background: color-mix(in oklab, var(--e2-bg) 88%, transparent);
     border-bottom:1px solid var(--e2-border);
   }
-  .e2-nav .inner{ height:60px; display:flex; align-items:center; justify-content:space-between }
+  .e2-nav .inner{
+    min-height:60px; display:flex; align-items:center; justify-content:space-between;
+    gap:1rem; flex-wrap:wrap;
+  }
+  .e2-nav nav{ flex-grow:1 }
+  .e2-nav nav .collapse{ width:100% }
+  .e2-nav-menu{
+    display:flex; flex-direction:column; align-items:flex-start; gap:1rem;
+    width:100%; padding:.75rem 0;
+  }
+  .e2-nav-links{
+    display:flex; flex-direction:column; gap:.75rem; width:100%;
+  }
+  .e2-nav-links a{ color: var(--e2-muted); font-weight:500 }
+  .e2-nav-controls{
+    display:flex; flex-direction:column; gap:.75rem; width:100%;
+  }
+  .e2-nav-controls .dropdown-toggle{ justify-content:space-between }
+  .e2-nav-controls .dropdown-menu{ padding:.5rem 0 }
+  .e2-nav-toggle{
+    display:inline-flex; align-items:center; justify-content:center; gap:.5rem;
+    padding:.55rem .75rem; border-radius: var(--e2-radius);
+    border:1px solid var(--e2-border); background: var(--e2-card);
+    color: var(--e2-text); box-shadow:none;
+  }
+  .e2-nav-toggle:hover{ background: var(--e2-surface) }
+  .e2-nav-toggle:focus-visible{ outline:2px solid var(--e2-primary); outline-offset:2px }
+  .e2-nav-toggle-icon{
+    position:relative; display:block; width:1.25rem; height:2px;
+    background: currentColor;
+  }
+  .e2-nav-toggle-icon::before,
+  .e2-nav-toggle-icon::after{
+    content:""; position:absolute; left:0; width:100%; height:2px;
+    background: currentColor;
+  }
+  .e2-nav-toggle-icon::before{ top:-6px }
+  .e2-nav-toggle-icon::after{ top:6px }
+  @media (min-width: 768px){
+    .e2-nav .inner{ flex-wrap:nowrap }
+    .e2-nav-menu{ flex-direction:row; align-items:center; justify-content:flex-end; gap:1.5rem; padding:0 }
+    .e2-nav-links{ flex-direction:row; align-items:center; gap:1.5rem; width:auto }
+    .e2-nav-controls{ flex-direction:row; align-items:center; gap:1rem; width:auto }
+    .e2-nav-controls .dropdown-toggle{ justify-content:center }
+  }
+  @media (max-width: 767.98px){
+    .e2-nav nav{ width:100% }
+    .e2-nav-menu{ border-top:1px solid var(--e2-border) }
+    .e2-nav-links li{ width:100% }
+    .e2-nav-links a{ display:block; padding:.25rem 0 }
+    .e2-nav-controls .e2-btn{ width:100%; justify-content:center }
+    .e2-nav-controls .dropdown-menu{ width:100%; min-width:0 }
+  }
   .e2-brand{ display:flex; align-items:center; gap:.6rem; font-weight:800; color:var(--e2-text) }
   .e2-nav a:hover{ text-decoration:none }
   


### PR DESCRIPTION
## Summary
- refactor the layout navigation to render links from a shared list and expose them through a Bootstrap collapse
- include the language dropdown and theme toggle inside the collapsible menu so they are reachable on mobile
- add responsive navigation and toggle button styles to match the design across breakpoints

## Testing
- php -l app/Views/layout.php

------
https://chatgpt.com/codex/tasks/task_e_68cfebc326e88323a268938ae4b023c0